### PR TITLE
lat/longitude extra_fields. cityDB.City() caching wrapper

### DIFF
--- a/pkg/extra_fields/extra_fields.go
+++ b/pkg/extra_fields/extra_fields.go
@@ -11,17 +11,21 @@ import (
 )
 
 type ExtraFields struct {
-	Country       string `json:"from_country,omitempty"`
-	CountrySource string `json:"from_country_source,omitempty"`
-	City          string `json:"from_city,omitempty"`
-	CitySource    string `json:"from_city_source,omitempty"`
-	CloudFront    int    `json:"cloudfront"`
-	Host          string `json:"host,omitempty"`
-	FromASN       string `json:"from_asn,omitempty"`
-	FromASDesc    string `json:"from_as_desc,omitempty"`
-	FromISP       string `json:"from_isp,omitempty"`
-	FromOrgName   string `json:"from_org_name,omitempty"`
-	Region        string `json:"from_region,omitempty"`
+	Country       string  `json:"from_country,omitempty"`
+	CountrySource string  `json:"from_country_source,omitempty"`
+	City          string  `json:"from_city,omitempty"`
+	CitySource    string  `json:"from_city_source,omitempty"`
+	Longitude     float64 `json:"from_longitude,omitempty"`
+	Latitude      float64 `json:"from_latitude,omitempty"`
+	CloudFront    int     `json:"cloudfront"`
+	Host          string  `json:"host,omitempty"`
+	FromASN       string  `json:"from_asn,omitempty"`
+	FromASDesc    string  `json:"from_as_desc,omitempty"`
+	FromISP       string  `json:"from_isp,omitempty"`
+	FromOrgName   string  `json:"from_org_name,omitempty"`
+	Region        string  `json:"from_region,omitempty"`
+
+	cityDBRec *geoip2.City
 }
 
 func (f *ExtraFields) GeoOrigin(req *http.Request) {
@@ -34,6 +38,26 @@ func (f *ExtraFields) GeoOrigin(req *http.Request) {
 
 	f.countryName(req, ip)
 	f.cityName(req, ip)
+	f.coordinates(req, ip)
+}
+
+//cityDB.City() wrapper function, to cache the result.
+//WARNING: It's suggested that IP argument will be the same within same ExtraFields set!
+func (f *ExtraFields) GetCityDBRecord(ip net.IP) (*geoip2.City, error) {
+	var (
+		err error
+		rec *geoip2.City
+	)
+	if f.cityDBRec == nil {
+		cityMux.RLock()
+		rec, err = cityDB.City(ip)
+		cityMux.RUnlock()
+		if err != nil {
+			return nil, err
+		}
+		f.cityDBRec = rec
+	}
+	return f.cityDBRec, err
 }
 
 func GetNginxHostname(req *http.Request) string {
@@ -71,13 +95,49 @@ func GetIPAdress(req *http.Request) net.IP {
 	return realIP
 }
 
+func (f *ExtraFields) coordinates(req *http.Request, ip net.IP) error {
+
+	afLongitude := GetMatchingHeader(req.Header, "x_af_longitude")
+	if afLongitude == "" {
+		geoRec, err := f.GetCityDBRecord(ip)
+		if err != nil {
+			logger.Get().Warnf("Could not get geoip cityDB record: %v", err)
+			return err
+		}
+		f.Longitude = geoRec.Location.Longitude
+	} else {
+		val, err := strconv.ParseFloat(afLongitude, 64)
+		if err == nil {
+			f.Longitude = val
+		} else {
+			logger.Get().Warnf("Could not parse longitude value: %s", afLongitude)
+		}
+	}
+
+	afLatitude := GetMatchingHeader(req.Header, "x_af_latitude")
+	if afLatitude == "" {
+		geoRec, err := f.GetCityDBRecord(ip)
+		if err != nil {
+			logger.Get().Warnf("Could not get geoip cityDB record: %v", err)
+			return err
+		}
+		f.Latitude = geoRec.Location.Latitude
+	} else {
+		val, err := strconv.ParseFloat(afLatitude, 64)
+		if err == nil {
+			f.Latitude = val
+		} else {
+			logger.Get().Warnf("Could not parse latitude value: %s", afLatitude)
+		}
+	}
+	return nil
+}
+
 func (f *ExtraFields) countryName(req *http.Request, ip net.IP) error {
 	afCountry := GetMatchingHeader(req.Header, "x_af_c_country")
 	if afCountry == "" && ip != nil {
 		// header key doesn't exist we should use GeoIP
-		cityMux.RLock()
-		record, err := cityDB.Country(ip)
-		cityMux.RUnlock()
+		record, err := f.GetCityDBRecord(ip)
 		if err != nil {
 			logger.Get().Warnf("Error: %v, for ip: %s", err, ip.String())
 			return err
@@ -98,9 +158,7 @@ func (f *ExtraFields) cityName(req *http.Request, ip net.IP) error {
 	afCity := GetMatchingHeader(req.Header, "x_af_c_city")
 	afRegion := GetMatchingHeader(req.Header, "x_af_c_region")
 	if afCity == "" && ip != nil {
-		cityMux.RLock()
-		record, err := cityDB.City(ip)
-		cityMux.RUnlock()
+		record, err := f.GetCityDBRecord(ip)
 		if err != nil {
 			logger.Get().Warnf("Error: %v, for ip: %s", err, ip.String())
 			return err

--- a/pkg/extra_fields/extra_fields.go
+++ b/pkg/extra_fields/extra_fields.go
@@ -36,9 +36,19 @@ func (f *ExtraFields) GeoOrigin(req *http.Request) {
 		return
 	}
 
-	f.countryName(req, ip)
-	f.cityName(req, ip)
-	f.coordinates(req, ip)
+	var err error
+	err = f.countryName(req, ip)
+	if err != nil {
+		logger.Get().Warnf("Could not set CountryName as an extra field")
+	}
+	err = f.cityName(req, ip)
+	if err != nil {
+		logger.Get().Warnf("Could not set CityName as an extra field")
+	}
+	err = f.coordinates(req, ip)
+	if err != nil {
+		logger.Get().Warnf("Could not set Coordinates (Latitude/Longitude) as extra fields")
+	}
 }
 
 //cityDB.City() wrapper function, to cache the result.

--- a/pkg/extra_fields/reader_test.go
+++ b/pkg/extra_fields/reader_test.go
@@ -12,17 +12,19 @@ import (
 )
 
 type EF struct {
-	ClientTs    int64  `json:"client_ts"`
-	CloudFront  int    `json:"cloudfront"`
-	FromAsDesc  string `json:"from_as_desc"`
-	FromAsn     string `json:"from_asn"`
-	FromCity    string `json:"from_city"`
-	FromCountry string `json:"from_country"`
-	FromRegion  string `json:"from_region"`
-	FromIsp     string `json:"from_isp"`
-	FromOrgName string `json:"from_org_name"`
-	Host        string `json:"host"`
-	ServerTs    int64  `json:"server_ts"`
+	ClientTs      int64   `json:"client_ts"`
+	CloudFront    int     `json:"cloudfront"`
+	FromAsDesc    string  `json:"from_as_desc"`
+	FromAsn       string  `json:"from_asn"`
+	FromCity      string  `json:"from_city"`
+	FromCountry   string  `json:"from_country"`
+	FromRegion    string  `json:"from_region"`
+	FromIsp       string  `json:"from_isp"`
+	FromOrgName   string  `json:"from_org_name"`
+	FromLatitude  float64 `json:"from_latitude"`
+	FromLongitude float64 `json:"from_longitude"`
+	Host          string  `json:"host"`
+	ServerTs      int64   `json:"server_ts"`
 }
 
 var raw []byte = []byte(`{"event":"test","payload":{"field": "hi"},"tail":"latest"}`)
@@ -37,6 +39,8 @@ func TestExtraFieldsFromHeaders(t *testing.T) {
 	fromAsn := "54500"
 	fromAsDesc := "AS54500"
 	fromIsp := "AnchorFree"
+	fromLatitude := float64(50.433300)
+	fromLongitude := float64(30.516700)
 	cloudFront := 1
 	fromOrgName := "EGIHosting"
 	serverTs := int64(1521800927956)
@@ -52,6 +56,8 @@ func TestExtraFieldsFromHeaders(t *testing.T) {
 	req.Header.Set("x_af_c_country", fromCountry)
 	req.Header.Set("x_af_c_city", fromCity)
 	req.Header.Set("x_af_c_region", fromRegion)
+	req.Header.Set("x_af_latitude", fmt.Sprintf("%f", fromLatitude))
+	req.Header.Set("x_af_longitude", fmt.Sprintf("%f", fromLongitude))
 	req.Header.Set("x_af_asn", fromAsn)
 	req.Header.Set("x_af_asdescription", fromAsDesc)
 	req.Header.Set("x_af_ispname", fromIsp)
@@ -77,6 +83,8 @@ func TestExtraFieldsFromHeaders(t *testing.T) {
 		assert.Equal(t, fromCity, rec.FromCity, "from_city field is not correct")
 		assert.Equal(t, fromRegion, rec.FromRegion, "from_region field is not correct")
 		assert.Equal(t, fromCountry, rec.FromCountry, "from_country field is not correct")
+		assert.Equal(t, fromLatitude, rec.FromLatitude, "from_latitude field is not correct")
+		assert.Equal(t, fromLongitude, rec.FromLongitude, "from_longitude field is not correct")
 		assert.Equal(t, fromIsp, rec.FromIsp, "from_isp field is not correct")
 		assert.Equal(t, fromOrgName, rec.FromOrgName, "from_org_name field is not correct")
 		assert.Equal(t, host, rec.Host, "host field is not correct")
@@ -135,6 +143,8 @@ func TestExtraFieldsFromCityDb(t *testing.T) {
 		assert.Equal(t, "London", rec.FromCity, "from_city field is not correct")
 		assert.Equal(t, "ENG", rec.FromRegion, "from_region field is not correct")
 		assert.Equal(t, "GB", rec.FromCountry, "from_country field is not correct")
+		assert.Equal(t, 51.5142, rec.FromLatitude, "from_latitude field is not correct")
+		assert.Equal(t, -0.0931, rec.FromLongitude, "from_longitude field is not correct")
 
 		if readerErr != nil {
 			break


### PR DESCRIPTION
- latitude (from_latitude), longitude (from_longitude) extra fields (report enrichment). Populate fields from X-AF-LATITUDE/X-AF-LONGITUDE headers if present; take data from MaxMind GeoIP database otherwise
- wrap cityDB.City() call to cache MaxMind database result. Suggesting that the IP won't change for the same extra fields set.