### PR TITLE
basic IPv6 filtering support

### DIFF
--- a/pkg/gdpr/gdpr.go
+++ b/pkg/gdpr/gdpr.go
@@ -35,9 +35,16 @@ func ipGDPR(address string) string {
 }
 
 func findIPs(msg []byte) [][]byte {
-	ret := ipv4Regex.FindAll(msg, -1)
+	ret := [][]byte{}
+	for _, ip := range ipv4Regex.FindAll(msg, -1) {
+		if net.ParseIP(string(ip)) != nil {
+			ret = append(ret, ip)
+		}
+	}
 	for _, matches := range ipv6Regex.FindAllSubmatch(msg, -1) {
-		ret = append(ret, matches[1])
+		if len(matches) > 2 && net.ParseIP(string(matches[1])) != nil {
+			ret = append(ret, matches[1])
+		}
 	}
 	return ret
 }

--- a/pkg/gdpr/gdpr.go
+++ b/pkg/gdpr/gdpr.go
@@ -10,6 +10,9 @@ import (
 
 var ipv4Regex = regexp.MustCompile(`([0-9]{1,3}\.){3}[0-9]{1,3}`)
 
+//no support for IPv4-IPv6 embedded notation
+var ipv6Regex = regexp.MustCompile(`(?i)(?:[^0-9a-f:])(([0-9a-f]{1,4}:){1,7}:|:(:[0-9a-f]{1,4}){1,7}|([0-9a-f]{1,4}:){1,7}[0-9a-f]{0,4}(:[0-9a-f]{1,4}){1,7})(?:[^0-9a-f:])`)
+
 type Reader struct {
 	line_reader.I
 	reader line_reader.I
@@ -32,7 +35,11 @@ func ipGDPR(address string) string {
 }
 
 func findIPs(msg []byte) [][]byte {
-	return ipv4Regex.FindAll(msg, -1)
+	ret := ipv4Regex.FindAll(msg, -1)
+	for _, matches := range ipv6Regex.FindAllSubmatch(msg, -1) {
+		ret = append(ret, matches[1])
+	}
+	return ret
 }
 
 func (r *Reader) ApplyGDPR(msg []byte) []byte {

--- a/pkg/gdpr/gdpr_test.go
+++ b/pkg/gdpr/gdpr_test.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"github.com/anchorfree/data-go/pkg/geo"
 	"github.com/stretchr/testify/assert"
+	"net"
 	"testing"
 )
 
@@ -199,5 +200,28 @@ func BenchmarkIPv6Regex(b *testing.B) {
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		ipv6Regex.FindAll(benchMsg, -1)
+	}
+}
+
+func BenchmarkParseIPv4(b *testing.B) {
+	b.ResetTimer()
+	str := "192.168.12.2"
+	for i := 0; i < b.N; i++ {
+		net.ParseIP(str)
+	}
+}
+
+func BenchmarkParseIPv6(b *testing.B) {
+	b.ResetTimer()
+	str := "2001:0db8:85a3:0000:0000:8a2e:0370:7334"
+	for i := 0; i < b.N; i++ {
+		net.ParseIP(str)
+	}
+}
+
+func BenchmarkFindIP(b *testing.B) {
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		findIPs(benchMsg)
 	}
 }

--- a/pkg/gdpr/gdpr_test.go
+++ b/pkg/gdpr/gdpr_test.go
@@ -2,6 +2,7 @@ package gdpr
 
 import (
 	"bytes"
+	"fmt"
 	"github.com/anchorfree/data-go/pkg/geo"
 	"github.com/stretchr/testify/assert"
 	"testing"
@@ -11,17 +12,21 @@ func Test_IPv4Filtering(t *testing.T) {
 	ip := string("193.43.210.30")
 	want := string("0.0.0.0")
 	got := ipGDPR(ip)
-	if want != got {
-		t.Fatalf("Want: %s, got %s", want, got)
-	}
+	assert.Equal(t, want, got)
 }
 
 func Test_IPv6Filtering(t *testing.T) {
-	ip := string("2001:db8:a0b:12f0::1")
-	want := string("::")
-	got := ipGDPR(ip)
-	if want != got {
-		t.Fatalf("Want: %s, got %s", want, got)
+	ips := []string{
+		"2001:db8:a0b:12f0::1",
+		"::12f0:0:1",
+		"23:A9::",
+		"::1",
+		"3281:DF:1::12",
+	}
+	for _, ip := range ips {
+		want := "::"
+		got := ipGDPR(ip)
+		assert.Equalf(t, want, got, "Incorectly filtered %s got: %v, want: %v", ip, got, want)
 	}
 }
 
@@ -50,6 +55,70 @@ func Test_FindIPv4(t *testing.T) {
 	}
 	for i := range expected {
 		assert.Equal(t, bytes.Compare(expected[i], result[i]), 0, "Did not match expected %v, got: %v", expected[i], result[i])
+	}
+}
+
+func Test_FindIPv6(t *testing.T) {
+	msg := []byte(`{
+			"payload": {
+				"ucr_hydra_mode": "sticky",
+				"time": 1521800858842,
+				"sampled": false,
+				"af_token": "3d416b03616ad3a80000000272677331"
+				"via": "2001:0db8:85a3:0000:0000:8a2e:0370:7334"
+			},
+			"host": "favoriteshoes.us",
+			"from_country_source": "ngx.var.geoip_country_code",
+			"cloudfront": 0,
+			"ngx_var_remote_addr": "3281:DF:1::12",
+			"from_country": "AE",
+			"from_ip": "A::B",
+			"server_ts": 1521800927956,
+			"client_ts": 1521800918976
+		}`)
+	expected := [][]byte{
+		[]byte("2001:0db8:85a3:0000:0000:8a2e:0370:7334"),
+		[]byte("3281:DF:1::12"),
+		[]byte("A::B"),
+	}
+	result := findIPs(msg)
+	assert.Equal(t, expected, result)
+	stringMsg := `{"event": "this is a test address %s to be found"}`
+	ips := []string{
+		"1:2:3:4:5:6:7:8",
+		"1:2:3:4:5:6:7::",
+		"1:2:3:4:5:6::8",
+		"1:2:3:4:5:6::8",
+		"1:2:3:4:5::7:8",
+		"1:2:3:4:5::8",
+		"1:2:3:4::6:7:8",
+		"1:2:3:4::8",
+		"1:2:3::5:6:7:8",
+		"1:2:3::8",
+		"1:2::4:5:6:7:8",
+		"1:2::8",
+		"1::",
+		"1::3:4:5:6:7:8",
+		"1::3:4:5:6:7:8",
+		"1::4:5:6:7:8",
+		"1::5:6:7:8",
+		"1::6:7:8",
+		"1::7:8",
+		"1::8",
+		"1::8",
+		"::2:3:4:5:6:7:8",
+		"::2:3:4:5:6:7:8",
+		"::8",
+		"FE80:0000:0000:0000:0202:B3FF:FE1E:8329",
+	}
+
+	for _, ip := range ips {
+		found := findIPs([]byte(fmt.Sprintf(stringMsg, ip)))
+		if len(found) > 0 {
+			assert.Equal(t, ip, string(found[0]))
+		} else {
+			assert.FailNowf(t, "Test failed", "could not find ip: %s", ip)
+		}
 	}
 }
 
@@ -99,4 +168,36 @@ func Test_MaskIPs(t *testing.T) {
 
 	//result := maskIPs(msg, findIPs(msg))
 	assert.Equal(t, bytes.Compare(expected, result), 0, "Did not match expected %v, got: %v", string(expected), string(result))
+}
+
+var benchMsg = []byte(`{
+		"payload": {
+			"ucr_hydra_mode": "sticky",
+			"time": 1521800858842,
+			"sampled": false,
+			"af_token": "3d416b03616ad3a80000000272677331"
+			"via": "74.115.4.69",
+		},
+		"host": "favoriteshoes.us",
+		"from_country_source": "ngx.var.geoip_country_code",
+		"cloudfront": 0,
+		"invalid_addr": "2001:0db8:85a3:0000:0000:8a2e:0370:7334",
+		"from_country": "AE",
+		"other_ip": "113.0.84.0/35",
+		"server_ts": 1521800927956,
+		"client_ts": 1521800918976
+	}`)
+
+func BenchmarkIPv4Regex(b *testing.B) {
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		ipv4Regex.FindAll(benchMsg, -1)
+	}
+}
+
+func BenchmarkIPv6Regex(b *testing.B) {
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		ipv6Regex.FindAll(benchMsg, -1)
+	}
 }

--- a/pkg/geo/geo_test.go
+++ b/pkg/geo/geo_test.go
@@ -17,6 +17,8 @@ func TestGeo(t *testing.T) {
 		198.8.84.226 af;
 		54.182.0.0/16 aws;
 		54.182.0.0/16 amz;
+		2400::/14 v6;
+		::1 lo;
 		`)
 	g := NewGeo().FromBytes(data)
 	assert.Equalf(t, 9, g.Len(), "Amount of IPs does not match")
@@ -28,6 +30,7 @@ func TestGeo(t *testing.T) {
 	assert.Truef(t, g.Match("54.182.1.1", "amz"), "Did not match af record")
 	assert.Falsef(t, g.Match("123.123.111.222", "af"), "Should not match record")
 	assert.Equalf(t, DefaultValue, g.Get("8.8.8.8"), "Should be default value")
+	assert.Truef(t, g.Match("2400::1:2:3", "v6"), "Did not match v6 record")
 }
 
 func BenchmarkGeo(b *testing.B) {


### PR DESCRIPTION
Basic IPv6 filtering
- no support for IPv4 in IPv6 embedded addresses
- no support for IPv4-mapped IPv6 addresses and IPv4-translated addresses

But IPv4 part of the mentioned above types of notations are going to be cleaned by IPv4 filter.