### PR TITLE
Added YAML support to event selector configuration

### DIFF
--- a/pkg/event_selector/event_selector.go
+++ b/pkg/event_selector/event_selector.go
@@ -1,7 +1,7 @@
 package event_selector
 
 import (
-	"encoding/json"
+	"gopkg.in/yaml.v2"
 	"sync"
 
 	"github.com/anchorfree/data-go/pkg/consul"
@@ -40,7 +40,7 @@ func (es *EventSelector) RunConfigWatcher() error {
 
 func (es *EventSelector) updateConfig(rawConfig []byte) error {
 	selectors := &Selectors{}
-	err := json.Unmarshal(rawConfig, selectors)
+	err := yaml.Unmarshal(rawConfig, selectors)
 	if err != nil {
 		return err
 	}

--- a/pkg/event_selector/selectors_config.go
+++ b/pkg/event_selector/selectors_config.go
@@ -1,10 +1,10 @@
 package event_selector
 
 type Selectors struct {
-	Selectors []Selector `json:"selectors"`
+	Selectors []Selector `yaml:"selectors"`
 }
 
 type Selector struct {
-	TargetTopic string            `json:"target_topic"`
-	Matching    map[string]string `json:"matching"`
+	TargetTopic string            `yaml:"target_topic"`
+	Matching    map[string]string `yaml:"matching"`
 }


### PR DESCRIPTION
Support both: 
```
{
  "selectors": [
    {
      "target_topic": "disconnect_request",
      "matching": {
        "event": "other_report",
        "payload.action_name": "disconnection_survey"
      }
    }
  ]
}
```

```
---
selectors:
- target_topic: disconnect_request
  matching:
    event: other_report
    payload.action_name: disconnection_survey
```